### PR TITLE
fix(daily_brief): exclude mgmt and internal logical units from IF_DOWN (closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `daily_brief`: exclude management interfaces (`fxp`/`me`/`vme`/`em`) and
+  internal logical units (`.16386`, `.32767`/`.32768`) from `IF_DOWN`
+  reporting, in addition to loopback. These are cosmetically "up down" and
+  were burying real anomalies on large fleets. Physical VC ports
+  (`sxe`/`vcp`) are intentionally still reported. Closes
+  [#13](https://github.com/shigechika/junos-mcp/issues/13).
+
 ## [0.14.0] - 2026-05-25
 
 ### Added

--- a/junos_mcp/server.py
+++ b/junos_mcp/server.py
@@ -46,6 +46,8 @@ _IF_DOWN_RE = re.compile(r"^(\S+)\s+up\s+down", re.MULTILINE)
 # Interfaces excluded from IF_DOWN reporting: loopback, management
 # (fxp/me/vme/em), and internal logical units (.16386 internal IFL,
 # .32767/.32768 virtual-chassis/internal) that are cosmetically "up down".
+# Physical VC ports (sxe/vcp) are intentionally NOT skipped: a down VC member
+# link can be a genuine fault.
 _IF_DOWN_SKIP_PREFIX = ("lo", "fxp", "me", "vme", "em")
 _IF_DOWN_SKIP_SUFFIX = (".16386", ".32767", ".32768")
 _SYSLOG_MAX_MATCHES = 10

--- a/junos_mcp/server.py
+++ b/junos_mcp/server.py
@@ -43,6 +43,11 @@ _SYSLOG_ALERT_RE = re.compile(
     re.IGNORECASE,
 )
 _IF_DOWN_RE = re.compile(r"^(\S+)\s+up\s+down", re.MULTILINE)
+# Interfaces excluded from IF_DOWN reporting: loopback, management
+# (fxp/me/vme/em), and internal logical units (.16386 internal IFL,
+# .32767/.32768 virtual-chassis/internal) that are cosmetically "up down".
+_IF_DOWN_SKIP_PREFIX = ("lo", "fxp", "me", "vme", "em")
+_IF_DOWN_SKIP_SUFFIX = (".16386", ".32767", ".32768")
 _SYSLOG_MAX_MATCHES = 10
 
 mcp = FastMCP("junos-mcp")
@@ -1253,7 +1258,8 @@ def _check_host_health(hostname: str, dev, since_hours: int) -> dict:
         down_ifs = [
             m.group(1)
             for m in _IF_DOWN_RE.finditer(out)
-            if not m.group(1).startswith("lo")
+            if not m.group(1).startswith(_IF_DOWN_SKIP_PREFIX)
+            and not m.group(1).endswith(_IF_DOWN_SKIP_SUFFIX)
         ]
         for iface in down_ifs:
             anomalies.append(f"[IF_DOWN] {iface}")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1424,6 +1424,24 @@ class TestCheckHostHealth:
         result = _check_host_health("rt1.example.jp", dev, since_hours=18)
         assert not any("[IF_DOWN]" in a for a in result["anomalies"])
 
+    def test_mgmt_and_internal_units_excluded(self):
+        """管理系(fxp/me/vme/em)と内部論理ユニット(.16386/.32767/.32768)は [IF_DOWN] から除外する"""
+        iface_out = (
+            "fxp0              up    down\n"
+            "me0               up    down\n"
+            "me0.0             up    down\n"
+            "vme               up    down\n"
+            "em0               up    down\n"
+            "ge-0/0/1.16386    up    down\n"
+            "ge-0/0/0.32767    up    down\n"
+            "ge-0/0/0.32768    up    down\n"
+            "ge-0/0/2          up    down\n"
+        )
+        dev = self._make_dev(interfaces=iface_out)
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        downs = [a for a in result["anomalies"] if "[IF_DOWN]" in a]
+        assert downs == ["[IF_DOWN] ge-0/0/2"]
+
     def test_syslog_in_window(self):
         """since_hours 以内の alert パターンを [SYSLOG] として検出する"""
         import datetime as _dt


### PR DESCRIPTION
## Problem
daily_brief IF_DOWN reporting flagged management interfaces (fxp/me/vme/em) and internal logical units (.16386 internal IFL, .32767/.32768 virtual-chassis/internal) that are cosmetically up/down. On a ~90-device fleet this produced hundreds of noise lines per run, burying real anomalies.

## Fix
Skip these in addition to loopback, via _IF_DOWN_SKIP_PREFIX / _IF_DOWN_SKIP_SUFFIX. Adds a regression test. All 116 tests pass.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)