### PR TITLE
fix(daily_brief): flag IF_DOWN only for described ports down within since_hours (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `daily_brief`: the interface-down check now uses `show interfaces
+  descriptions` instead of `show interfaces terse`. A physical interface is
+  flagged `[IF_DOWN]` only when it has a description (`Admin=up`, `Link=down`)
+  **and** its `Last flapped` time is within `since_hours`. This suppresses two
+  noise classes that survived [#13](https://github.com/shigechika/junos-mcp/issues/13):
+  undescribed unused access ports (no description) and chronically-down ports
+  (down for longer than the window). Real uplinks / inter-switch links carry
+  descriptions, so a genuine recent failure is still caught. Reported lines
+  now include the down-since timestamp. Closes
+  [#15](https://github.com/shigechika/junos-mcp/issues/15).
+
 ### Fixed
 - `daily_brief`: exclude management interfaces (`fxp`/`me`/`vme`/`em`) and
   internal logical units (`.16386`, `.32767`/`.32768`) from `IF_DOWN`

--- a/junos_mcp/server.py
+++ b/junos_mcp/server.py
@@ -42,7 +42,6 @@ _SYSLOG_ALERT_RE = re.compile(
     r"|IF_DOWN",
     re.IGNORECASE,
 )
-_IF_DOWN_RE = re.compile(r"^(\S+)\s+up\s+down", re.MULTILINE)
 # Interfaces excluded from IF_DOWN reporting: loopback, management
 # (fxp/me/vme/em), and internal logical units (.16386 internal IFL,
 # .32767/.32768 virtual-chassis/internal) that are cosmetically "up down".
@@ -50,6 +49,11 @@ _IF_DOWN_RE = re.compile(r"^(\S+)\s+up\s+down", re.MULTILINE)
 # link can be a genuine fault.
 _IF_DOWN_SKIP_PREFIX = ("lo", "fxp", "me", "vme", "em")
 _IF_DOWN_SKIP_SUFFIX = (".16386", ".32767", ".32768")
+# Absolute timestamp in "show interfaces <if>":
+# "Last flapped   : 2026-06-05 14:00:00 JST (1w0d 02:00 ago)"
+_LAST_FLAPPED_RE = re.compile(
+    r"Last flapped\s*:\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"
+)
 _SYSLOG_MAX_MATCHES = 10
 
 mcp = FastMCP("junos-mcp")
@@ -1211,6 +1215,28 @@ def _syslog_line_dt(line: str) -> "datetime.datetime | None":
         return None
 
 
+def _iface_last_flapped(dev, iface: str) -> "datetime.datetime | None":
+    """Return the ``Last flapped`` time of an interface, or None.
+
+    Parses the absolute timestamp from ``show interfaces <iface>``
+    (``Last flapped   : 2026-06-05 14:00:00 JST (...)``).  Returns None when
+    the field is absent (e.g. ``Never``) or unparseable.  The timestamp is
+    naive local time; JunOS prints it in the device's configured time zone,
+    which is assumed to match the server running this check.
+    """
+    try:
+        out = dev.cli(f"show interfaces {iface}", warning=False)
+    except Exception:
+        return None
+    m = _LAST_FLAPPED_RE.search(out)
+    if not m:
+        return None
+    try:
+        return datetime.datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return None
+
+
 def _check_host_health(hostname: str, dev, since_hours: int) -> dict:
     """Run four health checks on a single connected device.
 
@@ -1254,19 +1280,38 @@ def _check_host_health(hostname: str, dev, since_hours: int) -> dict:
     except Exception as exc:
         anomalies.append(f"[CHECK_ERROR] chassis alarms: {exc}")
 
-    # 3. Interface down
+    # 3. Interface down — report only described, admin-up ports whose link
+    #    went down within the window (issue #15).  ``show interfaces
+    #    descriptions`` lists only interfaces that have a description (= meant
+    #    to be in use); undescribed unused ports never appear.  ``Last
+    #    flapped`` filters out chronically-down ports, leaving genuine recent
+    #    failures (uplinks / inter-switch links carry descriptions).
     try:
-        out = dev.cli("show interfaces terse", warning=False)
-        down_ifs = [
-            m.group(1)
-            for m in _IF_DOWN_RE.finditer(out)
-            if not m.group(1).startswith(_IF_DOWN_SKIP_PREFIX)
-            and not m.group(1).endswith(_IF_DOWN_SKIP_SUFFIX)
-        ]
-        for iface in down_ifs:
-            anomalies.append(f"[IF_DOWN] {iface}")
+        out = dev.cli("show interfaces descriptions", warning=False)
+        cutoff = datetime.datetime.now() - datetime.timedelta(hours=since_hours)
+        for line in out.splitlines():
+            parts = line.split(None, 3)
+            # Columns: Interface  Admin  Link  Description
+            if len(parts) < 4 or parts[0] == "Interface":
+                continue
+            iface, admin, link = parts[0], parts[1].lower(), parts[2].lower()
+            if admin != "up" or link != "down":
+                continue
+            if iface.startswith(_IF_DOWN_SKIP_PREFIX) or iface.endswith(
+                _IF_DOWN_SKIP_SUFFIX
+            ):
+                continue
+            flapped = _iface_last_flapped(dev, iface)
+            if flapped is None:
+                # Link down but flap time unknown — report conservatively.
+                anomalies.append(f"[IF_DOWN] {iface} (described, link down)")
+            elif flapped >= cutoff:
+                anomalies.append(
+                    f"[IF_DOWN] {iface} (down since {flapped:%Y-%m-%d %H:%M})"
+                )
+            # else: down longer than since_hours — chronic, suppressed
     except Exception as exc:
-        anomalies.append(f"[CHECK_ERROR] interfaces terse: {exc}")
+        anomalies.append(f"[CHECK_ERROR] interfaces descriptions: {exc}")
 
     # 4. Syslog alert patterns within the time window
     try:
@@ -1301,7 +1346,11 @@ def daily_brief(
 
     Checks per host (Phase 1):
     - ``show system alarms`` / ``show chassis alarms``
-    - ``show interfaces terse`` — interface up/down (loopback excluded)
+    - ``show interfaces descriptions`` — a physical interface is flagged
+      ``[IF_DOWN]`` only when it has a description (``Admin=up``, ``Link=down``)
+      and its ``Last flapped`` time is within ``since_hours``.  Undescribed
+      unused ports and chronically-down ports are suppressed (loopback / mgmt /
+      internal logical units are also excluded).
     - ``show log messages | last 200`` — alert patterns within ``since_hours``
 
     Syslog patterns watched: BGP state change away from Established, STP port

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1385,16 +1385,39 @@ class TestSyslogLineDt:
 class TestCheckHostHealth:
     def _make_dev(self, system_alarms="No alarms currently active",
                   chassis_alarms="No alarms currently active",
-                  interfaces="ge-0/0/0          up    up",
+                  descriptions="",
+                  flapped=None,
                   syslog=""):
         dev = MagicMock()
-        dev.cli.side_effect = lambda cmd, **kw: {
-            "show system alarms": system_alarms,
-            "show chassis alarms": chassis_alarms,
-            "show interfaces terse": interfaces,
-            "show log messages | last 200": syslog,
-        }[cmd]
+        flaps = flapped or {}
+
+        def _cli(cmd, **kw):
+            if cmd == "show system alarms":
+                return system_alarms
+            if cmd == "show chassis alarms":
+                return chassis_alarms
+            if cmd == "show interfaces descriptions":
+                return descriptions
+            if cmd == "show log messages | last 200":
+                return syslog
+            if cmd.startswith("show interfaces "):
+                iface = cmd.split()[2]
+                ts = flaps.get(iface)
+                head = f"Physical interface: {iface}, Enabled, Physical link is Down\n"
+                if ts is None:
+                    return head
+                return head + f"  Last flapped   : {ts} JST (1w0d 00:00 ago)\n"
+            raise KeyError(cmd)
+
+        dev.cli.side_effect = _cli
         return dev
+
+    @staticmethod
+    def _recent_ts():
+        import datetime as _dt
+        return (_dt.datetime.now() - _dt.timedelta(hours=2)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
 
     def test_all_clean(self):
         """正常なデバイスは anomalies が空"""
@@ -1410,37 +1433,81 @@ class TestCheckHostHealth:
         result = _check_host_health("rt1.example.jp", dev, since_hours=18)
         assert any("[ALARM]" in a for a in result["anomalies"])
 
-    def test_interface_down(self):
-        """up/down インターフェースを [IF_DOWN] として検出する"""
-        iface_out = "ge-0/0/0          up    up\nge-0/0/1          up    down\n"
-        dev = self._make_dev(interfaces=iface_out)
+    def test_described_recent_down_reported(self):
+        """description 付き・admin up・link down で直近 flap のポートを検出する"""
+        desc = (
+            "Interface       Admin Link Description\n"
+            "ge-0/0/1        up    down To_uplink\n"
+        )
+        dev = self._make_dev(
+            descriptions=desc, flapped={"ge-0/0/1": self._recent_ts()}
+        )
         result = _check_host_health("rt1.example.jp", dev, since_hours=18)
         assert any("[IF_DOWN] ge-0/0/1" in a for a in result["anomalies"])
 
-    def test_loopback_excluded(self):
-        """lo0 down は [IF_DOWN] に含めない"""
-        iface_out = "lo0               up    down\n"
-        dev = self._make_dev(interfaces=iface_out)
+    def test_undescribed_port_not_reported(self):
+        """description が無いポートは descriptions に現れず [IF_DOWN] にならない"""
+        desc = (
+            "Interface       Admin Link Description\n"
+            "ge-0/0/2        up    up   To_core\n"
+        )
+        dev = self._make_dev(descriptions=desc)
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        assert not any("[IF_DOWN]" in a for a in result["anomalies"])
+
+    def test_chronic_down_suppressed(self):
+        """description 付きでも flap が since_hours より古ければ抑止する"""
+        desc = (
+            "Interface       Admin Link Description\n"
+            "xe-0/1/1        up    down To_old\n"
+        )
+        dev = self._make_dev(
+            descriptions=desc, flapped={"xe-0/1/1": "2025-06-20 05:10:25"}
+        )
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        assert not any("[IF_DOWN]" in a for a in result["anomalies"])
+
+    def test_admin_down_excluded(self):
+        """admin down（意図的な無効化）は report しない"""
+        desc = (
+            "Interface       Admin Link Description\n"
+            "ge-0/0/3        down  down To_disabled\n"
+        )
+        dev = self._make_dev(
+            descriptions=desc, flapped={"ge-0/0/3": self._recent_ts()}
+        )
         result = _check_host_health("rt1.example.jp", dev, since_hours=18)
         assert not any("[IF_DOWN]" in a for a in result["anomalies"])
 
     def test_mgmt_and_internal_units_excluded(self):
-        """管理系(fxp/me/vme/em)と内部論理ユニット(.16386/.32767/.32768)は [IF_DOWN] から除外する"""
-        iface_out = (
-            "fxp0              up    down\n"
-            "me0               up    down\n"
-            "me0.0             up    down\n"
-            "vme               up    down\n"
-            "em0               up    down\n"
-            "ge-0/0/1.16386    up    down\n"
-            "ge-0/0/0.32767    up    down\n"
-            "ge-0/0/0.32768    up    down\n"
-            "ge-0/0/2          up    down\n"
+        """管理系(me)と内部論理ユニット(.16386)は description 付き down でも除外する"""
+        desc = (
+            "Interface       Admin Link Description\n"
+            "me0             up    down mgmt\n"
+            "ge-0/0/1.16386  up    down internal\n"
+            "ge-0/0/4        up    down To_real\n"
         )
-        dev = self._make_dev(interfaces=iface_out)
+        dev = self._make_dev(
+            descriptions=desc,
+            flapped={
+                "me0": self._recent_ts(),
+                "ge-0/0/1.16386": self._recent_ts(),
+                "ge-0/0/4": self._recent_ts(),
+            },
+        )
         result = _check_host_health("rt1.example.jp", dev, since_hours=18)
         downs = [a for a in result["anomalies"] if "[IF_DOWN]" in a]
-        assert downs == ["[IF_DOWN] ge-0/0/2"]
+        assert len(downs) == 1 and "ge-0/0/4" in downs[0]
+
+    def test_flap_unknown_reported_conservatively(self):
+        """flap 時刻不明でも link down なら保守的に report する"""
+        desc = (
+            "Interface       Admin Link Description\n"
+            "ge-0/0/5        up    down To_x\n"
+        )
+        dev = self._make_dev(descriptions=desc, flapped={})
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        assert any("[IF_DOWN] ge-0/0/5" in a for a in result["anomalies"])
 
     def test_syslog_in_window(self):
         """since_hours 以内の alert パターンを [SYSLOG] として検出する"""


### PR DESCRIPTION
## Summary
Closes #15. After #13 (mgmt/internal exclusions), `daily_brief` still flooded WARNING with **unused physical access ports** that are cosmetically `up down`. This makes the interface-down check description- and recency-aware.

A physical interface is reported `[IF_DOWN]` only when **both**:
- **has a description** — appears in `show interfaces descriptions` with `Admin=up`, `Link=down` (undescribed unused ports never appear)
- **went down recently** — its `Last flapped` time is within `since_hours`

Two noise classes are dropped: undescribed unused ports, and chronically-down described ports (down for longer than the window). Uplinks / inter-switch links carry descriptions, so genuine recent failures are still caught. Reported lines now include the down-since timestamp.

## Implementation
- Replace `show interfaces terse` scan with `show interfaces descriptions` parsing (`Interface/Admin/Link/Description` columns).
- New helper `_iface_last_flapped()` parses the absolute `Last flapped` timestamp from `show interfaces <if>` and compares to `now - since_hours`.
- Existing `_IF_DOWN_SKIP_PREFIX/SUFFIX` (loopback / mgmt / internal IFL) kept as a pre-filter. Physical VC ports (sxe/vcp) unaffected.
- `admin=down` (deliberately disabled) ports are not reported.
- Flap time unknown (`Never` / unparseable) → reported conservatively.

## Verified on live devices (2026-06-05)
- `brs-sw`: 22 undescribed `ge-0/0/x` down → now **0** (descriptions lists 5 IFs, all up).
- `med-sw xe-0/1/1`: no description + `Last flapped 2025-06-20` (≈50w) → suppressed on both counts.

## Tests
`TestCheckHostHealth` rewritten for the new logic (6 IF_DOWN cases: recent-described reported, undescribed not reported, chronic suppressed, admin-down excluded, mgmt/internal excluded, flap-unknown conservative). **119 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)