### PR TITLE
feat: add daily_brief health-summary tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ While [junos-ops](https://github.com/shigechika/junos-ops) is the CLI tool for h
 | `collect_rsi` | Collect RSI/SCF with model-specific timeouts | Yes |
 | `collect_rsi_batch` | Collect RSI/SCF from multiple devices in parallel (supports tag filter) | Yes |
 
+### Daily Brief
+
+| Tool | Description | Connection |
+|------|-------------|:----------:|
+| `daily_brief` | One-shot health summary across devices — facts / RE redundancy, uptime & load average, system alarms, and route-summary counts — returning CRITICAL/WARNING/OK tiers in parallel (supports tag filter). Optional `route_baseline` flags an unexpected `inet.0` destination count. | Yes |
+
 ### Pre-flight Checks
 
 Equivalent to the `junos-ops check` subcommand modes. All three reuse the
@@ -279,7 +285,7 @@ mcp dev junos_mcp/server.py
 pytest tests/ -v
 ```
 
-94 tests covering all 22 tools, the connection pool, helper functions, and edge cases.
+105 tests covering all 23 tools, the connection pool, helper functions, and edge cases.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ mcp dev junos_mcp/server.py
 pytest tests/ -v
 ```
 
-105 tests covering all 23 tools, the connection pool, helper functions, and edge cases.
+116 tests covering all 23 tools, the connection pool, helper functions, and edge cases.
 
 ## Architecture
 

--- a/junos_mcp/server.py
+++ b/junos_mcp/server.py
@@ -1,8 +1,8 @@
 """MCP server exposing junos-ops device operations.
 
-Provides 22 tools for Juniper Networks device management: device info,
+Provides 23 tools for Juniper Networks device management: device info,
 CLI execution, config management, firmware upgrade, RSI/SCF collection,
-and pre-flight checks.
+pre-flight checks, and a daily-brief health summary.
 
 Supports STDIO and Streamable HTTP transports.
 
@@ -16,6 +16,7 @@ module, so the MCP STDIO JSON-RPC channel is safe by construction.
 """
 
 import argparse
+import datetime
 import os
 import os.path
 import re
@@ -1111,6 +1112,206 @@ def schedule_reboot(
         )
 
     return _connect_and_run(hostname, config_path, _operation)
+
+
+# ---------------------------------------------------------------------------
+# daily_brief — one-shot health summary for morning patrol
+# ---------------------------------------------------------------------------
+
+# "... load averages: 0.20, 0.18, 0.15" — captures the 1-minute average.
+_LOAD_RE = re.compile(r"load averages?:\s*([\d.]+)")
+# "... up 45 days, ..." — captures uptime in whole days (absent for < 1 day).
+_UPTIME_DAYS_RE = re.compile(r"\bup\s+(\d+)\s+day")
+# "inet.0: 152 destinations, 200 routes (152 active, ...)" per routing table.
+_ROUTE_TABLE_RE = re.compile(
+    r"^(inet6?\.0):\s+(\d+) destinations,\s+\d+ routes \((\d+) active", re.MULTILINE
+)
+
+
+def _collect_brief(dev, load_threshold: float, route_baseline: int = 0) -> dict:
+    """Run generic JUNOS health checks on a connected device for daily_brief.
+
+    Checks device facts (model/version, routing-engine redundancy), system
+    uptime/load average, system alarms, and route-summary counts. Returns
+    ``{"anomalies": list[str], "info": dict}`` where each anomaly is prefixed
+    ``CRITICAL:`` or ``WARNING:``. ``route_baseline`` (when > 0) flags an
+    ``inet.0`` destination count that differs from the expected value.
+    """
+    anomalies: list[str] = []
+    info: dict = {}
+
+    # Device facts (model / version / RE redundancy) — cached on connect.
+    try:
+        facts = dev.facts
+        info["model"] = facts.get("model") or "?"
+        info["version"] = facts.get("version") or "?"
+        if facts.get("2RE"):
+            for re_name in ("RE0", "RE1"):
+                re_info = facts.get(re_name) or {}
+                status = (re_info.get("status") or "").strip()
+                if status and status.lower() != "ok":
+                    anomalies.append(f"CRITICAL: {re_name} status={status}")
+    except Exception as exc:
+        anomalies.append(f"WARNING: cannot read facts: {exc}")
+
+    # Uptime / load average ("show system uptime").
+    try:
+        uptime_out = dev.cli("show system uptime")
+        m = _LOAD_RE.search(uptime_out)
+        if m:
+            load1 = float(m.group(1))
+            info["load"] = load1
+            if load1 > load_threshold:
+                anomalies.append(f"WARNING: load average {load1} > {load_threshold}")
+        days = _UPTIME_DAYS_RE.search(uptime_out)
+        if days:
+            info["uptime"] = f"{days.group(1)}d"
+        else:
+            info["uptime"] = "<1d"
+            anomalies.append("WARNING: uptime < 1 day — recent reboot?")
+    except Exception as exc:
+        anomalies.append(f"WARNING: uptime check failed: {exc}")
+
+    # System alarms ("show system alarms"). Major -> CRITICAL, Minor -> WARNING.
+    try:
+        alarm_out = dev.cli("show system alarms")
+        if "No alarms currently active" in alarm_out:
+            info["alarms"] = 0
+        else:
+            count = 0
+            for line in alarm_out.splitlines():
+                cls = re.search(r"\b(Major|Minor)\b", line)
+                if not cls:
+                    continue
+                count += 1
+                desc = line.strip()
+                tier = "CRITICAL" if cls.group(1) == "Major" else "WARNING"
+                anomalies.append(f"{tier}: alarm: {desc}")
+            info["alarms"] = count
+            if count == 0:
+                # Active alarms reported but the rows could not be parsed.
+                anomalies.append("WARNING: active alarms present (unparsed)")
+    except Exception as exc:
+        anomalies.append(f"WARNING: alarm check failed: {exc}")
+
+    # Route summary ("show route summary") — inet.0 / inet6.0 counts.
+    try:
+        route_out = dev.cli("show route summary")
+        routes: dict = {}
+        for tbl, dest, active in _ROUTE_TABLE_RE.findall(route_out):
+            routes[tbl] = {"destinations": int(dest), "active": int(active)}
+        if routes:
+            info["routes"] = routes
+        if route_baseline and "inet.0" in routes:
+            dest = routes["inet.0"]["destinations"]
+            if dest != route_baseline:
+                anomalies.append(
+                    f"WARNING: inet.0 {dest} destinations (baseline {route_baseline})"
+                )
+    except Exception as exc:
+        anomalies.append(f"WARNING: route summary failed: {exc}")
+
+    return {"anomalies": anomalies, "info": info}
+
+
+@mcp.tool()
+def daily_brief(
+    hostnames: list[str] | None = None,
+    tags: list[str] | None = None,
+    load_threshold: float = 2.0,
+    route_baseline: int = 0,
+    max_workers: int = 5,
+    config_path: str = "",
+) -> str:
+    """Run health checks on JUNOS devices and return a Markdown daily brief.
+
+    Checks device facts (model/version, routing-engine redundancy), system
+    uptime/load average, system alarms, and route-summary counts (inet.0 /
+    inet6.0), reporting CRITICAL/WARNING/OK per device with a summary. Select
+    targets via ``hostnames``, ``tags``, or both (default: all configured
+    devices).
+
+    Args:
+        hostnames: Target device hostnames (must exist in config.ini).
+        tags: Tag filter (same semantics as run_show_command_batch).
+        load_threshold: 1-minute load average above which a WARNING is raised.
+        route_baseline: When > 0, flag any device whose inet.0 destination
+            count differs from this value. Scope with ``tags`` — e.g.
+            ``tags=["main"], route_baseline=152`` — because full-table routers
+            carry far more routes than access routers.
+        max_workers: Maximum parallel threads (default 5).
+        config_path: Path to config.ini (empty string uses default search).
+    """
+    err = _ensure_config(config_path)
+    if err:
+        return err
+
+    targets = _resolve_hostnames(hostnames, tags)
+    if isinstance(targets, str):
+        return targets
+    if not targets:
+        return "No hosts resolved."
+
+    def _check_one(hostname):
+        def _operation(_hostname, dev):
+            return _collect_brief(dev, load_threshold, route_baseline)
+
+        result = _connect_and_run(hostname, config_path, _operation)
+        if isinstance(result, dict):
+            return result
+        # _connect_and_run returned an error string (connection/config failure).
+        return {"anomalies": [f"CRITICAL: {result}"], "info": {}}
+
+    results = common.run_parallel(_check_one, targets, max_workers=max_workers)
+
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    lines = [f"## JUNOS デイリーブリーフ（{now}）", ""]
+    critical_count = warning_count = ok_count = 0
+
+    for host in targets:
+        r = results.get(host) or {"anomalies": ["CRITICAL: no result"], "info": {}}
+        anomalies = r.get("anomalies", [])
+        info = r.get("info", {})
+
+        criticals = [a for a in anomalies if a.startswith("CRITICAL")]
+        warnings = [a for a in anomalies if a.startswith("WARNING")]
+        if criticals:
+            status = "CRITICAL"
+            critical_count += 1
+        elif warnings:
+            status = "WARNING"
+            warning_count += 1
+        else:
+            status = "OK"
+            ok_count += 1
+
+        lines.append(f"### {host} [{status}]")
+        load = info.get("load")
+        load_str = f"  load: {load}" if load is not None else ""
+        lines.append(
+            f"- model: {info.get('model', '?')}  JUNOS {info.get('version', '?')}"
+            f"  uptime: {info.get('uptime', '?')}{load_str}"
+        )
+        routes = info.get("routes")
+        if routes:
+            parts = [
+                f"{tbl} {routes[tbl]['destinations']}dest/{routes[tbl]['active']}active"
+                for tbl in ("inet.0", "inet6.0")
+                if tbl in routes
+            ]
+            if parts:
+                lines.append(f"- routes: {'  '.join(parts)}")
+        for a in criticals + warnings:
+            lines.append(f"- {a}")
+        lines.append("")
+
+    lines += [
+        "### サマリー",
+        f"- CRITICAL: {critical_count} 台",
+        f"- WARNING:  {warning_count} 台",
+        f"- OK:       {ok_count} 台",
+    ]
+    return "\n".join(lines)
 
 
 if __name__ == "__main__":

--- a/junos_mcp/server.py
+++ b/junos_mcp/server.py
@@ -1122,10 +1122,18 @@ def schedule_reboot(
 _LOAD_RE = re.compile(r"load averages?:\s*([\d.]+)")
 # "... up 45 days, ..." — captures uptime in whole days (absent for < 1 day).
 _UPTIME_DAYS_RE = re.compile(r"\bup\s+(\d+)\s+day")
+# Any uptime summary line ("... up 45 days ..." or "... up 3:21 ..."). Counting
+# these distinguishes a genuine sub-day uptime from unparseable output, and on a
+# dual-RE chassis there is one such line per RE.
+_UPTIME_LINE_RE = re.compile(r"\bup\s+\d")
 # "inet.0: 152 destinations, 200 routes (152 active, ...)" per routing table.
+# The ^ anchor (re.MULTILINE) keeps routing-instance tables (``VRF.inet.0:``) out.
 _ROUTE_TABLE_RE = re.compile(
     r"^(inet6?\.0):\s+(\d+) destinations,\s+\d+ routes \((\d+) active", re.MULTILINE
 )
+# RE <status> strings that indicate a genuine fault. A healthy backup RE may
+# report Present/Online/Backup (platform-dependent), so only these page CRITICAL.
+_RE_FAULT_STATES = {"fault", "fail", "failed", "offline", "absent", "empty", "testing"}
 
 
 def _collect_brief(dev, load_threshold: float, route_baseline: int = 0) -> dict:
@@ -1149,26 +1157,35 @@ def _collect_brief(dev, load_threshold: float, route_baseline: int = 0) -> dict:
             for re_name in ("RE0", "RE1"):
                 re_info = facts.get(re_name) or {}
                 status = (re_info.get("status") or "").strip()
-                if status and status.lower() != "ok":
+                # The RE <status> string is platform/version dependent — a healthy
+                # backup may report Present/Online/Backup, not "OK" — so page only
+                # on an explicit fault state, never on the mere absence of "OK".
+                if status.lower() in _RE_FAULT_STATES:
                     anomalies.append(f"CRITICAL: {re_name} status={status}")
     except Exception as exc:
         anomalies.append(f"WARNING: cannot read facts: {exc}")
 
-    # Uptime / load average ("show system uptime").
+    # Uptime / load average ("show system uptime"). A dual-RE chassis prints one
+    # block per RE, so report the worst case: the highest load and shortest uptime.
     try:
         uptime_out = dev.cli("show system uptime")
-        m = _LOAD_RE.search(uptime_out)
-        if m:
-            load1 = float(m.group(1))
-            info["load"] = load1
-            if load1 > load_threshold:
-                anomalies.append(f"WARNING: load average {load1} > {load_threshold}")
-        days = _UPTIME_DAYS_RE.search(uptime_out)
-        if days:
-            info["uptime"] = f"{days.group(1)}d"
-        else:
+        loads = [float(x) for x in _LOAD_RE.findall(uptime_out)]
+        if loads:
+            max_load = max(loads)
+            info["load"] = max_load
+            if max_load > load_threshold:
+                anomalies.append(f"WARNING: load average {max_load} > {load_threshold}")
+        day_counts = [int(d) for d in _UPTIME_DAYS_RE.findall(uptime_out)]
+        uptime_lines = len(_UPTIME_LINE_RE.findall(uptime_out))
+        if not uptime_lines:
+            info["uptime"] = "?"
+            anomalies.append("WARNING: could not parse system uptime")
+        elif len(day_counts) < uptime_lines:
+            # At least one RE block lacks a day count, i.e. has been up < 1 day.
             info["uptime"] = "<1d"
             anomalies.append("WARNING: uptime < 1 day — recent reboot?")
+        else:
+            info["uptime"] = f"{min(day_counts)}d"
     except Exception as exc:
         anomalies.append(f"WARNING: uptime check failed: {exc}")
 
@@ -1256,7 +1273,13 @@ def daily_brief(
         def _operation(_hostname, dev):
             return _collect_brief(dev, load_threshold, route_baseline)
 
-        result = _connect_and_run(hostname, config_path, _operation)
+        # Isolate per-host failures: _connect_and_run only catches
+        # PoolConnectionError, so a connection-setup error of any other type
+        # (e.g. a malformed port) must not escape and abort the whole brief.
+        try:
+            result = _connect_and_run(hostname, config_path, _operation)
+        except Exception as exc:  # noqa: BLE001
+            return {"anomalies": [f"CRITICAL: {exc}"], "info": {}}
         if isinstance(result, dict):
             return result
         # _connect_and_run returned an error string (connection/config failure).
@@ -1269,7 +1292,11 @@ def daily_brief(
     critical_count = warning_count = ok_count = 0
 
     for host in targets:
-        r = results.get(host) or {"anomalies": ["CRITICAL: no result"], "info": {}}
+        r = results.get(host)
+        if not isinstance(r, dict):
+            # common.run_parallel stores a sentinel (int 1) when a worker raised;
+            # coerce any non-dict so one bad host cannot crash the whole render.
+            r = {"anomalies": ["CRITICAL: no result"], "info": {}}
         anomalies = r.get("anomalies", [])
         info = r.get("info", {})
 
@@ -1303,6 +1330,9 @@ def daily_brief(
                 lines.append(f"- routes: {'  '.join(parts)}")
         for a in criticals + warnings:
             lines.append(f"- {a}")
+        if status == "OK":
+            # Affirm the checks ran and passed (mirrors the sibling MCPs).
+            lines.append("- 異常なし（alarms: なし）")
         lines.append("")
 
     lines += [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,7 @@
 import argparse
 import configparser
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -1347,19 +1347,127 @@ def test_collect_brief_minor_alarm_warns():
     assert any(a.startswith("WARNING: alarm") and "Rescue" in a for a in r["anomalies"])
 
 
-def test_collect_brief_dual_re_down_critical():
+def test_collect_brief_dual_re_fault_critical():
+    """An explicit RE fault status pages CRITICAL."""
     dev = _fake_dev(
         facts={
             "model": "MX480",
             "version": "21.4R3",
             "2RE": True,
             "RE0": {"status": "OK"},
-            "RE1": {"status": "Present"},
+            "RE1": {"status": "Fault"},
         },
         uptime="up 5 days, load averages: 0.10, 0.10, 0.10",
     )
     r = _collect_brief(dev, 2.0)
-    assert any("CRITICAL: RE1 status=Present" in a for a in r["anomalies"])
+    assert any("CRITICAL: RE1 status=Fault" in a for a in r["anomalies"])
+
+
+def test_collect_brief_dual_re_healthy_backup_no_warn():
+    """A healthy backup RE (status Present/Backup, not 'OK') must NOT page."""
+    dev = _fake_dev(
+        facts={
+            "model": "MX480",
+            "version": "21.4R3",
+            "2RE": True,
+            "RE0": {"status": "OK", "mastership_state": "master"},
+            "RE1": {"status": "Present", "mastership_state": "backup"},
+        },
+        uptime="up 5 days, load averages: 0.10, 0.10, 0.10",
+    )
+    r = _collect_brief(dev, 2.0)
+    assert not any("RE1" in a for a in r["anomalies"])
+
+
+def test_collect_brief_dual_re_uptime_worst_case():
+    """With per-RE blocks, the highest load and a sub-day RE are surfaced."""
+    dev = _fake_dev(
+        facts={"model": "MX480", "version": "21", "2RE": True, "RE0": {"status": "OK"}, "RE1": {"status": "OK"}},
+        uptime=(
+            "re0:\n--------\n12:00PM  up 45 days, 4:00, 1 user, load averages: 0.20, 0.18, 0.15\n"
+            "\nre1:\n--------\n12:00PM  up 3:21, 1 user, load averages: 2.50, 2.10, 1.90"
+        ),
+    )
+    r = _collect_brief(dev, 2.0)
+    assert r["info"]["load"] == 2.50  # max across REs
+    assert r["info"]["uptime"] == "<1d"  # re1 rebooted
+    assert any("load average 2.5" in a for a in r["anomalies"])
+    assert any("recent reboot" in a for a in r["anomalies"])
+
+
+def test_collect_brief_uptime_unparseable_warns_not_reboot():
+    """Empty/garbled uptime is reported as a parse failure, not a reboot."""
+    dev = _fake_dev(uptime="garbage with no uptime line")
+    r = _collect_brief(dev, 2.0)
+    assert r["info"]["uptime"] == "?"
+    assert any("could not parse" in a for a in r["anomalies"])
+    assert not any("recent reboot" in a for a in r["anomalies"])
+
+
+def test_collect_brief_facts_failure_warns():
+    """A facts read failure degrades to a WARNING; other sections still run."""
+    dev = _fake_dev(uptime="up 5 days, load averages: 0.10, 0.10, 0.10")
+    type(dev).facts = PropertyMock(side_effect=RuntimeError("rpc auth failed"))
+    r = _collect_brief(dev, 2.0)
+    assert any(a.startswith("WARNING: cannot read facts:") for a in r["anomalies"])
+    assert "model" not in r["info"]  # falls back to "?" in the brief
+    assert r["info"]["uptime"] == "5d"  # other checks still populate
+
+
+def test_collect_brief_cli_failure_warns_per_section():
+    """A dev.cli failure on one command degrades only that section."""
+    dev = _fake_dev()
+
+    def _cli(command):
+        if "alarms" in command:
+            raise RuntimeError("RpcTimeoutError")
+        if "uptime" in command:
+            return "up 5 days, load averages: 0.10, 0.10, 0.10"
+        if "route summary" in command:
+            return "inet.0: 152 destinations, 200 routes (152 active, 0 holddown, 0 hidden)"
+        return ""
+
+    dev.cli.side_effect = _cli
+    r = _collect_brief(dev, 2.0)
+    assert any(a.startswith("WARNING: alarm check failed:") for a in r["anomalies"])
+    assert r["info"]["uptime"] == "5d"
+    assert r["info"]["routes"]["inet.0"]["destinations"] == 152
+
+
+def test_collect_brief_multiple_alarms():
+    """Two alarm rows yield count==2 with one CRITICAL and one WARNING; the
+    header and count lines are not miscounted."""
+    dev = _fake_dev(
+        uptime="up 10 days, load averages: 0.10, 0.10, 0.10",
+        alarms=(
+            "2 alarms currently active\n"
+            "Alarm time               Class  Description\n"
+            "2024-01-01 00:00:00 UTC  Major  PEM 0 Not OK\n"
+            "2024-01-01 00:00:00 UTC  Minor  Rescue configuration is not set"
+        ),
+    )
+    r = _collect_brief(dev, 2.0)
+    assert r["info"]["alarms"] == 2
+    assert sum(a.startswith("CRITICAL: alarm") for a in r["anomalies"]) == 1
+    assert sum(a.startswith("WARNING: alarm") for a in r["anomalies"]) == 1
+
+
+def test_collect_brief_route_ignores_vrf_and_mgmt_tables():
+    """Routing-instance tables (VRF/mgmt) must not leak into inet.0 counts."""
+    dev = _fake_dev(
+        uptime="up 5 days, load averages: 0.10, 0.10, 0.10",
+        routes=(
+            "inet.0: 152 destinations, 200 routes (152 active, 0 holddown, 0 hidden)\n"
+            "mgmt_junos.inet.0: 3 destinations, 3 routes (3 active, 0 holddown, 0 hidden)\n"
+            "VRF-CUST.inet.0: 9999 destinations, 12000 routes (9999 active, 0 holddown, 0 hidden)\n"
+            "inet6.0: 30 destinations, 40 routes (30 active, 0 holddown, 0 hidden)\n"
+            "VRF-CUST.inet6.0: 500 destinations, 600 routes (500 active, 0 holddown, 0 hidden)"
+        ),
+    )
+    r = _collect_brief(dev, 2.0, route_baseline=152)
+    assert set(r["info"]["routes"]) == {"inet.0", "inet6.0"}
+    assert r["info"]["routes"]["inet.0"] == {"destinations": 152, "active": 152}
+    assert not any("baseline" in a for a in r["anomalies"])  # VRF's 9999 must not fire
 
 
 def test_collect_brief_route_baseline_deviation_warns():
@@ -1435,3 +1543,68 @@ def test_daily_brief_no_hosts_resolved():
     ):
         out = daily_brief(hostnames=[])
     assert "No hosts resolved" in out
+
+
+def test_daily_brief_route_baseline_forwarded_end_to_end():
+    """route_baseline reaches _collect_brief through the real _operation closure."""
+    fake = _fake_dev(
+        uptime="up 5 days, load averages: 0.1, 0.1, 0.1",
+        routes="inet.0: 160 destinations, 200 routes (160 active, 0 holddown, 0 hidden)",
+    )
+    with (
+        patch("junos_mcp.server._ensure_config", return_value=None),
+        patch("junos_mcp.server._resolve_hostnames", return_value=["rt1.example.jp"]),
+        patch("junos_mcp.server._connect_and_run", side_effect=lambda h, cp, op: op(h, fake)),
+    ):
+        out = daily_brief(hostnames=["rt1.example.jp"], route_baseline=152)
+    assert "[WARNING]" in out
+    assert "baseline 152" in out and "160" in out
+
+
+def test_daily_brief_dropped_worker_is_critical_not_crash():
+    """A non-dict result (the int sentinel run_parallel stores on a crashed
+    worker) degrades to CRITICAL instead of crashing the whole brief."""
+    targets = ["rt1.example.jp", "rt2.example.jp"]
+    canned = {
+        "rt1.example.jp": {"anomalies": [], "info": {"model": "MX240"}},
+        "rt2.example.jp": 1,  # run_parallel sentinel for a raised worker
+    }
+    with (
+        patch("junos_mcp.server._ensure_config", return_value=None),
+        patch("junos_mcp.server._resolve_hostnames", return_value=targets),
+        patch("junos_mcp.server.common.run_parallel", return_value=canned),
+    ):
+        out = daily_brief(hostnames=targets)
+    assert "### rt2.example.jp [CRITICAL]" in out
+    assert "CRITICAL: no result" in out
+    assert "CRITICAL: 1 台" in out
+
+
+def test_daily_brief_connection_setup_exception_is_critical():
+    """An exception raised by _connect_and_run (not just a returned error
+    string) is isolated per host and rendered CRITICAL."""
+    with (
+        patch("junos_mcp.server._ensure_config", return_value=None),
+        patch("junos_mcp.server._resolve_hostnames", return_value=["rt1.example.jp"]),
+        patch("junos_mcp.server._connect_and_run", side_effect=ValueError("invalid port")),
+    ):
+        out = daily_brief(hostnames=["rt1.example.jp"])
+    assert "[CRITICAL]" in out
+    assert "invalid port" in out
+
+
+def test_daily_brief_ok_device_shows_normal_line():
+    canned = {
+        "rt1.example.jp": {
+            "anomalies": [],
+            "info": {"model": "MX240", "version": "21", "uptime": "30d", "load": 0.1, "alarms": 0},
+        }
+    }
+    with (
+        patch("junos_mcp.server._ensure_config", return_value=None),
+        patch("junos_mcp.server._resolve_hostnames", return_value=["rt1.example.jp"]),
+        patch("junos_mcp.server._connect_and_run", side_effect=lambda h, cp, op: canned[h]),
+    ):
+        out = daily_brief(hostnames=["rt1.example.jp"])
+    assert "[OK]" in out
+    assert "異常なし" in out

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,7 @@ import pytest
 import junos_mcp.pool as pool_module
 from junos_ops import common
 from junos_mcp.server import (
+    _collect_brief,
     _connect_and_run,
     _ensure_config,
     _init_globals,
@@ -33,6 +34,7 @@ from junos_mcp.server import (
     get_router_list,
     get_version,
     list_remote_files,
+    daily_brief,
     run_show_command,
     run_show_command_batch,
     run_show_commands,
@@ -1260,3 +1262,176 @@ class TestScheduleReboot:
         result = schedule_reboot("rt1.example.jp", "2601020304", dry_run=False)
         assert "FAILED" in result
         assert "code=4" in result
+
+
+# ---------------------------------------------------------------------------
+# daily_brief
+# ---------------------------------------------------------------------------
+
+
+def _fake_dev(facts=None, uptime="", alarms="No alarms currently active", routes=""):
+    """Build a MagicMock JUNOS device for _collect_brief tests."""
+    dev = MagicMock()
+    dev.facts = facts if facts is not None else {"model": "MX240", "version": "21.4R3-S1", "2RE": False}
+
+    def _cli(command):
+        if "uptime" in command:
+            return uptime
+        if "alarms" in command:
+            return alarms
+        if "route summary" in command:
+            return routes
+        return ""
+
+    dev.cli.side_effect = _cli
+    return dev
+
+
+_HEALTHY_UPTIME = "ydc-gw1 ... up 45 days, 3:21, 2 users, load averages: 0.20, 0.18, 0.15"
+
+
+def test_collect_brief_all_ok():
+    dev = _fake_dev(
+        uptime=_HEALTHY_UPTIME,
+        routes=(
+            "inet.0: 152 destinations, 200 routes (152 active, 0 holddown, 0 hidden)\n"
+            "inet6.0: 30 destinations, 40 routes (30 active, 0 holddown, 0 hidden)"
+        ),
+    )
+    r = _collect_brief(dev, 2.0)
+    assert r["anomalies"] == []
+    assert r["info"]["load"] == 0.20
+    assert r["info"]["uptime"] == "45d"
+    assert r["info"]["alarms"] == 0
+    assert r["info"]["routes"]["inet.0"] == {"destinations": 152, "active": 152}
+    assert r["info"]["routes"]["inet6.0"]["active"] == 30
+
+
+def test_collect_brief_high_load_warns():
+    dev = _fake_dev(uptime="up 10 days, load averages: 2.50, 2.10, 1.90")
+    r = _collect_brief(dev, 2.0)
+    assert any("WARNING: load average 2.5" in a for a in r["anomalies"])
+
+
+def test_collect_brief_recent_reboot_warns():
+    dev = _fake_dev(uptime="up 3:21, 2 users, load averages: 0.10, 0.10, 0.10")
+    r = _collect_brief(dev, 2.0)
+    assert r["info"]["uptime"] == "<1d"
+    assert any("recent reboot" in a for a in r["anomalies"])
+
+
+def test_collect_brief_major_alarm_critical():
+    dev = _fake_dev(
+        uptime="up 10 days, load averages: 0.10, 0.10, 0.10",
+        alarms=(
+            "1 alarms currently active\n"
+            "Alarm time               Class  Description\n"
+            "2024-01-01 00:00:00 UTC  Major  PEM 0 Not OK"
+        ),
+    )
+    r = _collect_brief(dev, 2.0)
+    assert r["info"]["alarms"] == 1
+    assert any(a.startswith("CRITICAL: alarm") and "PEM 0" in a for a in r["anomalies"])
+
+
+def test_collect_brief_minor_alarm_warns():
+    dev = _fake_dev(
+        uptime="up 10 days, load averages: 0.10, 0.10, 0.10",
+        alarms=(
+            "1 alarms currently active\n"
+            "Alarm time               Class  Description\n"
+            "2024-01-01 00:00:00 UTC  Minor  Rescue configuration is not set"
+        ),
+    )
+    r = _collect_brief(dev, 2.0)
+    assert any(a.startswith("WARNING: alarm") and "Rescue" in a for a in r["anomalies"])
+
+
+def test_collect_brief_dual_re_down_critical():
+    dev = _fake_dev(
+        facts={
+            "model": "MX480",
+            "version": "21.4R3",
+            "2RE": True,
+            "RE0": {"status": "OK"},
+            "RE1": {"status": "Present"},
+        },
+        uptime="up 5 days, load averages: 0.10, 0.10, 0.10",
+    )
+    r = _collect_brief(dev, 2.0)
+    assert any("CRITICAL: RE1 status=Present" in a for a in r["anomalies"])
+
+
+def test_collect_brief_route_baseline_deviation_warns():
+    dev = _fake_dev(
+        uptime="up 5 days, load averages: 0.10, 0.10, 0.10",
+        routes="inet.0: 160 destinations, 200 routes (160 active, 0 holddown, 0 hidden)",
+    )
+    r = _collect_brief(dev, 2.0, route_baseline=152)
+    assert any("baseline 152" in a and "160" in a for a in r["anomalies"])
+
+
+def test_collect_brief_route_baseline_match_no_warn():
+    dev = _fake_dev(
+        uptime="up 5 days, load averages: 0.10, 0.10, 0.10",
+        routes="inet.0: 152 destinations, 200 routes (152 active, 0 holddown, 0 hidden)",
+    )
+    r = _collect_brief(dev, 2.0, route_baseline=152)
+    assert not any("baseline" in a for a in r["anomalies"])
+
+
+def test_daily_brief_formats_tiers_and_summary():
+    canned = {
+        "rt1.example.jp": {
+            "anomalies": ["CRITICAL: RE1 status=Present"],
+            "info": {"model": "MX480", "version": "21", "uptime": "45d", "load": 0.1},
+        },
+        "rt2.example.jp": {
+            "anomalies": ["WARNING: load average 2.5 > 2.0"],
+            "info": {"model": "MX240", "version": "21", "uptime": "10d", "load": 2.5},
+        },
+        "rt3.example.jp": {
+            "anomalies": [],
+            "info": {
+                "model": "MX240",
+                "version": "21",
+                "uptime": "30d",
+                "load": 0.2,
+                "routes": {"inet.0": {"destinations": 152, "active": 152}},
+            },
+        },
+    }
+    targets = list(canned)
+    with (
+        patch("junos_mcp.server._ensure_config", return_value=None),
+        patch("junos_mcp.server._resolve_hostnames", return_value=targets),
+        patch("junos_mcp.server._connect_and_run", side_effect=lambda h, cp, op: canned[h]),
+    ):
+        out = daily_brief(hostnames=targets)
+    assert "### rt1.example.jp [CRITICAL]" in out
+    assert "### rt2.example.jp [WARNING]" in out
+    assert "### rt3.example.jp [OK]" in out
+    assert "- routes: inet.0 152dest/152active" in out
+    assert "CRITICAL: 1 台" in out
+    assert "WARNING:  1 台" in out
+    assert "OK:       1 台" in out
+
+
+def test_daily_brief_connection_error_is_critical():
+    with (
+        patch("junos_mcp.server._ensure_config", return_value=None),
+        patch("junos_mcp.server._resolve_hostnames", return_value=["rt1.example.jp"]),
+        patch("junos_mcp.server._connect_and_run", return_value="Connection error: boom"),
+    ):
+        out = daily_brief(hostnames=["rt1.example.jp"])
+    assert "[CRITICAL]" in out
+    assert "Connection error: boom" in out
+
+
+def test_daily_brief_no_hosts_resolved():
+    with (
+        patch("junos_mcp.server._ensure_config", return_value=None),
+        patch("junos_mcp.server._resolve_hostnames", return_value=[]),
+    ):
+        out = daily_brief(hostnames=[])
+    assert "No hosts resolved" in out


### PR DESCRIPTION
## Summary

Adds a **`daily_brief`** MCP tool to junos-mcp — the last of the sibling MCPs
(`eos-mcp`, `aruba-central-mcp`, `keycloak-mcp`, `zapi-mcp`) to gain the
morning-patrol one-shot health brief. Mirrors eos-mcp's `daily_brief` shape:
per-device CRITICAL/WARNING/OK tiers + a summary, in parallel, Markdown output.

## What it checks (generic JUNOS health)
- **Facts**: model / version, and **routing-engine redundancy** (a down RE on a
  dual-RE chassis → CRITICAL)
- **Uptime / load** (`show system uptime`): 1-min load over `load_threshold`
  (default 2.0) → WARNING; uptime < 1 day → WARNING (recent reboot)
- **Alarms** (`show system alarms`): Major → CRITICAL, Minor → WARNING
- **Route summary** (`show route summary`): inet.0 / inet6.0 destination &
  active counts reported per device for at-a-glance comparison (e.g. gw1 vs gw2)

## Site-specifics kept out of the core
`daily_brief` stays generic. The one NichidaiSRE-style knob is an optional
**`route_baseline`** parameter: when > 0 it flags any device whose `inet.0`
destination count differs from the expected value. Scope it with `tags` —
e.g. `daily_brief(tags=["main"], route_baseline=152)` — since full-table
routers carry far more routes than access routers. No hardcoded hostnames or
baselines in the server.

## Tests
- 11 new tests (parsing of load / uptime / alarms / routes, dual-RE,
  route_baseline, tier formatting & summary, connection-error handling)
- Full suite: **105 passed** (was 94)

## Notes
- Tool name `daily_brief` is intentional (CLI `show ... brief` lineage; sibling
  unification) per the project's naming note.
- Follow-up (separate, in NichidaiSRE): the `junos-route-patrol` skill can call
  `mcp__junos-mcp__daily_brief` instead of the manual `run_show_command_batch`
  steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)