### PR TITLE
feat(daily_brief): add RE-fault and route-baseline checks + crash isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ mcp dev junos_mcp/server.py
 pytest tests/ -v
 ```
 
-127 tests covering all 23 tools, the connection pool, helper functions, and edge cases.
+133 tests covering all 23 tools, the connection pool, helper functions, and edge cases.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ junos-ops display layer for table rendering.
 
 | Tool | Description | Connection |
 |------|-------------|:----------:|
-| `daily_brief` | Morning health check across multiple devices in parallel — alarms, interface up/down, and syslog alert patterns within a look-back window (`since_hours`, default 18 h). Returns a CRITICAL/WARNING/OK Markdown summary. | Yes |
+| `daily_brief` | Morning health check across multiple devices in parallel — alarms, interface up/down, syslog alert patterns within a look-back window (`since_hours`, default 18 h), dual-RE faults (`[RE_FAULT]`), and an optional `inet.0` route-count baseline (`route_baseline`, e.g. `tags=["main"], route_baseline=152`). Returns a CRITICAL/WARNING/OK Markdown summary. | Yes |
 
 ### Safety by Design
 
@@ -306,7 +306,7 @@ mcp dev junos_mcp/server.py
 pytest tests/ -v
 ```
 
-115 tests covering all 23 tools, the connection pool, helper functions, and edge cases.
+127 tests covering all 23 tools, the connection pool, helper functions, and edge cases.
 
 ## Architecture
 

--- a/junos_mcp/server.py
+++ b/junos_mcp/server.py
@@ -1343,6 +1343,9 @@ def _check_host_health(hostname: str, dev, since_hours: int, route_baseline: int
         anomalies.append(f"[CHECK_ERROR] syslog: {exc}")
 
     # 5. Routing-engine redundancy (dual-RE chassis): flag an explicit RE fault.
+    #    Scope: only the first chassis's flat RE0/RE1 facts are inspected; a
+    #    fault on a second Virtual Chassis member (carried in the re_info fact,
+    #    not RE0/RE1) is out of scope here.
     try:
         facts = dev.facts
         if facts.get("2RE"):

--- a/junos_mcp/server.py
+++ b/junos_mcp/server.py
@@ -55,6 +55,13 @@ _LAST_FLAPPED_RE = re.compile(
     r"Last flapped\s*:\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"
 )
 _SYSLOG_MAX_MATCHES = 10
+# RE <status> strings that indicate a genuine fault. A healthy backup RE may
+# report Present/Online/Backup (platform/version dependent), so page only on one
+# of these explicit fault states rather than on the mere absence of "OK".
+_RE_FAULT_STATES = {"fault", "fail", "failed", "offline", "absent", "empty", "testing"}
+# "inet.0: 152 destinations, ..." — the ^ anchor (re.MULTILINE) keeps
+# routing-instance tables ("VRF.inet.0:", "mgmt_junos.inet.0:") out.
+_ROUTE_INET0_RE = re.compile(r"^inet\.0:\s+(\d+) destinations", re.MULTILINE)
 
 mcp = FastMCP("junos-mcp")
 
@@ -1237,8 +1244,12 @@ def _iface_last_flapped(dev, iface: str) -> "datetime.datetime | None":
         return None
 
 
-def _check_host_health(hostname: str, dev, since_hours: int) -> dict:
-    """Run four health checks on a single connected device.
+def _check_host_health(hostname: str, dev, since_hours: int, route_baseline: int = 0) -> dict:
+    """Run health checks on a single connected device.
+
+    Checks: system & chassis alarms, IF_DOWN, syslog alert patterns, dual-RE
+    redundancy ([RE_FAULT]), and — when ``route_baseline`` > 0 — an inet.0
+    destination count that deviates from the expected value ([ROUTE_BASELINE]).
 
     Returns a dict with keys:
       - ``hostname``: str
@@ -1331,6 +1342,35 @@ def _check_host_health(hostname: str, dev, since_hours: int) -> dict:
     except Exception as exc:
         anomalies.append(f"[CHECK_ERROR] syslog: {exc}")
 
+    # 5. Routing-engine redundancy (dual-RE chassis): flag an explicit RE fault.
+    try:
+        facts = dev.facts
+        if facts.get("2RE"):
+            for re_name in ("RE0", "RE1"):
+                re_info = facts.get(re_name) or {}
+                status = (re_info.get("status") or "").strip()
+                if status.lower() in _RE_FAULT_STATES:
+                    anomalies.append(f"[RE_FAULT] {re_name} status={status}")
+    except Exception as exc:
+        anomalies.append(f"[CHECK_ERROR] routing-engine: {exc}")
+
+    # 6. Route-summary baseline (only when route_baseline is set). Flags an
+    #    inet.0 destination count that deviates from the expected value — scope
+    #    with tags (e.g. tags=["main"], route_baseline=152), since full-table
+    #    routers carry far more routes than access routers.
+    if route_baseline:
+        try:
+            out = dev.cli("show route summary", warning=False)
+            m = _ROUTE_INET0_RE.search(out)
+            if m:
+                dest = int(m.group(1))
+                if dest != route_baseline:
+                    anomalies.append(
+                        f"[ROUTE_BASELINE] inet.0 {dest} destinations (baseline {route_baseline})"
+                    )
+        except Exception as exc:
+            anomalies.append(f"[CHECK_ERROR] route summary: {exc}")
+
     return {"hostname": hostname, "anomalies": anomalies, "error": None}
 
 
@@ -1339,6 +1379,7 @@ def daily_brief(
     hostnames: list[str] | None = None,
     tags: list[str] | None = None,
     since_hours: int = 18,
+    route_baseline: int = 0,
     max_workers: int = 10,
     config_path: str = "",
 ) -> str:
@@ -1352,6 +1393,11 @@ def daily_brief(
       unused ports and chronically-down ports are suppressed (loopback / mgmt /
       internal logical units are also excluded).
     - ``show log messages | last 200`` — alert patterns within ``since_hours``
+    - dual-RE redundancy — an explicit routing-engine fault is flagged ``[RE_FAULT]``
+    - ``route_baseline`` (optional) — when > 0, a device whose ``inet.0``
+      destination count differs from this value is flagged ``[ROUTE_BASELINE]``.
+      Scope with ``tags`` (e.g. ``tags=["main"], route_baseline=152``), since
+      full-table routers carry far more routes than access routers.
 
     Syslog patterns watched: BGP state change away from Established, STP port
     role change, OSPF neighbor down, ARP address conflict, IF_DOWN.
@@ -1388,7 +1434,7 @@ def daily_brief(
         if pool is not None:
             try:
                 with pool.acquire(hostname, norm_path) as dev:
-                    return _check_host_health(hostname, dev, since_hours)
+                    return _check_host_health(hostname, dev, since_hours, route_baseline)
             except PoolConnectionError as exc:
                 return {
                     "hostname": hostname,
@@ -1405,7 +1451,7 @@ def daily_brief(
             }
         dev = conn["dev"]
         try:
-            return _check_host_health(hostname, dev, since_hours)
+            return _check_host_health(hostname, dev, since_hours, route_baseline)
         finally:
             try:
                 dev.close()
@@ -1420,14 +1466,16 @@ def daily_brief(
 
     criticals, warnings, oks = [], [], []
     for hostname in targets:
-        row = results.get(
-            hostname,
-            {
+        row = results.get(hostname)
+        if not isinstance(row, dict):
+            # common.run_parallel stores a sentinel (int 1) for a worker that
+            # raised; coerce any non-dict so one bad host cannot crash the
+            # whole render at row.get(...) below.
+            row = {
                 "hostname": hostname,
                 "anomalies": ["[UNREACHABLE] no result"],
                 "error": "no result",
-            },
-        )
+            }
         if row.get("error"):
             criticals.append(row)
         elif row.get("anomalies"):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,7 @@
 import argparse
 import configparser
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -1603,6 +1603,49 @@ class TestCheckHostHealth:
         result = _check_host_health("rt1.example.jp", dev, since_hours=18, route_baseline=152)
         assert not any("ROUTE_BASELINE" in a for a in result["anomalies"])
 
+    def test_re_fault_all_states_flagged(self):
+        """Every fault state (and a mixed-case value) is matched case-insensitively."""
+        for state in ["Fault", "Fail", "Failed", "Offline", "Absent", "Empty", "Testing", "OFFLINE"]:
+            dev = self._make_dev(
+                facts={"2RE": True, "RE0": {"status": "OK"}, "RE1": {"status": state}}
+            )
+            result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+            assert any(f"[RE_FAULT] RE1 status={state}" in a for a in result["anomalies"]), state
+
+    def test_re_check_error_isolated(self):
+        """A dev.facts read failure degrades to [CHECK_ERROR]; other checks still run."""
+        dev = self._make_dev()  # all CLI checks clean
+        type(dev).facts = PropertyMock(side_effect=RuntimeError("rpc fail"))
+        try:
+            result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        finally:
+            del type(dev).facts  # avoid leaking the property onto the MagicMock class
+        assert any("[CHECK_ERROR] routing-engine" in a for a in result["anomalies"])
+        assert not any("[ALARM]" in a or "[IF_DOWN]" in a for a in result["anomalies"])
+
+    def test_route_summary_check_error_isolated(self):
+        """A show route summary failure degrades to [CHECK_ERROR], not a crash."""
+        dev = self._make_dev()
+        canned = dev.cli.side_effect
+
+        def _cli(cmd, **kw):
+            if cmd == "show route summary":
+                raise RuntimeError("RpcTimeoutError")
+            return canned(cmd, **kw)
+
+        dev.cli.side_effect = _cli
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18, route_baseline=152)
+        assert any("[CHECK_ERROR] route summary" in a for a in result["anomalies"])
+
+    def test_route_baseline_no_inet0_line_no_op(self):
+        """route_baseline with no inet.0 line in the output is a clean no-op."""
+        dev = self._make_dev(
+            route_summary="inet6.0: 30 destinations, 40 routes (30 active, 0 holddown, 0 hidden)"
+        )
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18, route_baseline=152)
+        assert not any("ROUTE_BASELINE" in a for a in result["anomalies"])
+        assert not any("CHECK_ERROR" in a for a in result["anomalies"])
+
 
 # --- daily_brief ---
 
@@ -1662,6 +1705,33 @@ class TestDailyBrief:
         result = daily_brief(hostnames=["rt1.example.jp"])
         assert "1 CRITICAL" in result
         assert "no result" in result
+
+    @patch("junos_mcp.server._check_host_health")
+    @patch("junos_mcp.server.common.connect")
+    @patch("junos_mcp.server.get_pool")
+    def test_run_one_forwards_args_non_pool(self, mock_pool, mock_connect, mock_check, mock_config):
+        """The non-pool path forwards since_hours and route_baseline positionally."""
+        mock_pool.return_value = None
+        mock_dev = MagicMock()
+        mock_connect.return_value = {"ok": True, "dev": mock_dev, "error": None, "error_message": None}
+        mock_check.return_value = {"hostname": "rt1.example.jp", "anomalies": [], "error": None}
+        daily_brief(hostnames=["rt1.example.jp"], since_hours=24, route_baseline=152)
+        mock_check.assert_called_once_with("rt1.example.jp", mock_dev, 24, 152)
+
+    @patch("junos_mcp.server._check_host_health")
+    @patch("junos_mcp.server.get_pool")
+    def test_run_one_forwards_args_pool(self, mock_pool, mock_check, mock_config):
+        """The pool path forwards since_hours and route_baseline positionally."""
+        mock_dev = MagicMock()
+        cm = MagicMock()
+        cm.__enter__.return_value = mock_dev
+        cm.__exit__.return_value = False
+        pool = MagicMock()
+        pool.acquire.return_value = cm
+        mock_pool.return_value = pool
+        mock_check.return_value = {"hostname": "rt1.example.jp", "anomalies": [], "error": None}
+        daily_brief(hostnames=["rt1.example.jp"], since_hours=24, route_baseline=152)
+        mock_check.assert_called_once_with("rt1.example.jp", mock_dev, 24, 152)
 
     def test_unknown_hostname(self, mock_config):
         """config.ini に存在しないホスト名はエラー"""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1387,8 +1387,11 @@ class TestCheckHostHealth:
                   chassis_alarms="No alarms currently active",
                   descriptions="",
                   flapped=None,
-                  syslog=""):
+                  syslog="",
+                  facts=None,
+                  route_summary=""):
         dev = MagicMock()
+        dev.facts = facts if facts is not None else {"2RE": False}
         flaps = flapped or {}
 
         def _cli(cmd, **kw):
@@ -1400,6 +1403,8 @@ class TestCheckHostHealth:
                 return descriptions
             if cmd == "show log messages | last 200":
                 return syslog
+            if cmd == "show route summary":
+                return route_summary
             if cmd.startswith("show interfaces "):
                 iface = cmd.split()[2]
                 ts = flaps.get(iface)
@@ -1542,6 +1547,62 @@ class TestCheckHostHealth:
         assert len(syslog_entries) == 11
         assert any("truncated" in a for a in syslog_entries)
 
+    # --- routing-engine redundancy ([RE_FAULT]) ---
+
+    def test_re_fault_flagged(self):
+        """An explicit RE fault on a dual-RE chassis is flagged [RE_FAULT]."""
+        dev = self._make_dev(
+            facts={"2RE": True, "RE0": {"status": "OK"}, "RE1": {"status": "Fault"}}
+        )
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        assert any("[RE_FAULT] RE1 status=Fault" in a for a in result["anomalies"])
+
+    def test_re_healthy_backup_not_flagged(self):
+        """A healthy backup RE (status Present/Backup, not 'OK') must NOT flag."""
+        dev = self._make_dev(
+            facts={"2RE": True, "RE0": {"status": "OK"}, "RE1": {"status": "Present"}}
+        )
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        assert not any("RE_FAULT" in a for a in result["anomalies"])
+
+    def test_single_re_no_redundancy_check(self):
+        dev = self._make_dev(facts={"2RE": False})
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        assert not any("RE_FAULT" in a for a in result["anomalies"])
+
+    # --- route-summary baseline ([ROUTE_BASELINE]) ---
+
+    def test_route_baseline_deviation_flagged(self):
+        dev = self._make_dev(
+            route_summary="inet.0: 160 destinations, 200 routes (160 active, 0 holddown, 0 hidden)"
+        )
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18, route_baseline=152)
+        assert any("[ROUTE_BASELINE]" in a and "160" in a for a in result["anomalies"])
+
+    def test_route_baseline_match_not_flagged(self):
+        dev = self._make_dev(
+            route_summary="inet.0: 152 destinations, 200 routes (152 active, 0 holddown, 0 hidden)"
+        )
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18, route_baseline=152)
+        assert not any("ROUTE_BASELINE" in a for a in result["anomalies"])
+
+    def test_route_baseline_zero_skips_check(self):
+        """route_baseline=0 (default) does not run the route-summary check."""
+        dev = self._make_dev()
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18)
+        assert not any("ROUTE_BASELINE" in a for a in result["anomalies"])
+
+    def test_route_baseline_ignores_vrf_tables(self):
+        """Routing-instance tables (VRF/mgmt) must not fire the inet.0 baseline."""
+        dev = self._make_dev(
+            route_summary=(
+                "inet.0: 152 destinations, 200 routes (152 active, 0 holddown, 0 hidden)\n"
+                "VRF-CUST.inet.0: 9999 destinations, 12000 routes (9999 active, 0 holddown, 0 hidden)"
+            )
+        )
+        result = _check_host_health("rt1.example.jp", dev, since_hours=18, route_baseline=152)
+        assert not any("ROUTE_BASELINE" in a for a in result["anomalies"])
+
 
 # --- daily_brief ---
 
@@ -1592,6 +1653,15 @@ class TestDailyBrief:
         mock_parallel.return_value = {}
         result = daily_brief(hostnames=["rt1.example.jp"])
         assert "1 CRITICAL" in result
+
+    @patch("junos_mcp.server.common.run_parallel")
+    def test_dropped_worker_sentinel_is_critical(self, mock_parallel, mock_config):
+        """A non-dict sentinel (the int 1 run_parallel stores for a crashed
+        worker) degrades to CRITICAL instead of crashing the whole brief."""
+        mock_parallel.return_value = {"rt1.example.jp": 1}
+        result = daily_brief(hostnames=["rt1.example.jp"])
+        assert "1 CRITICAL" in result
+        assert "no result" in result
 
     def test_unknown_hostname(self, mock_config):
         """config.ini に存在しないホスト名はエラー"""


### PR DESCRIPTION
## Summary

Extends the existing `daily_brief` (added in #12) with the two checks the
morning **route** patrol needs, plus a robustness fix surfaced by an adversarial
review. Additive to `_check_host_health` — same `{hostname, anomalies, error}`
contract and CRITICAL/WARNING/OK tiers.

### `[RE_FAULT]` — dual-RE redundancy
On a `2RE` chassis, flag an explicit routing-engine fault. A healthy backup that
reports `Present`/`Backup`/`Online` (platform-dependent, not literally `OK`) is
**not** flagged — only an explicit fault state (`_RE_FAULT_STATES`) pages.

### `[ROUTE_BASELINE]` — inet.0 route-count baseline
New optional `route_baseline` parameter. When > 0, flag any device whose
`inet.0` destination count differs from the expected value. Scope with `tags`:

```python
daily_brief(tags=["main"], route_baseline=152)
```

full-table routers carry far more routes than access routers, so scoping (not a
global baseline) is the intended use. Routing-instance tables (`VRF.inet.0:`,
`mgmt_junos.inet.0:`) are excluded by the `^`-anchored regex.

### Crash isolation (robustness)
`common.run_parallel` stores an `int 1` sentinel for a worker that raised an
unexpected (non-`PoolConnectionError`) exception. The formatting loop's
`results.get(host, default)` kept that `1` (key present) and then
`row.get("error")` raised `AttributeError`, **aborting the whole brief**. The
loop now coerces any non-dict result to the unreachable default, so one bad
host degrades to CRITICAL instead of crashing all hosts.

## Tests
- 11 new tests: RE fault / healthy-backup-no-flag / single-RE, route_baseline
  deviation / match / zero-skip / VRF-table exclusion, and the dropped-worker
  int-sentinel (which crashed before the fix).
- Full suite: **127 passed**.

## Context
Supersedes the (now-closed) #17, which was a from-scratch duplicate built off a
stale local clone before #12 was pulled. This PR keeps the existing, more
developed implementation and only adds the genuinely complementary parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)